### PR TITLE
Include sslmode as command line argument

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -19,6 +19,7 @@ type config struct {
 	dbname   string
 	retry    int
 	sleep    int
+	sslmode  string
 }
 
 var c config
@@ -70,10 +71,15 @@ func init() {
 		"sleep",
 		1,
 		"sleep")
+	
+	checkCmd.Flags().StringVar(&c.sslmode,
+		"sslmode",
+		"require",
+		"sslmode")
 }
 
 func check(c config) {
-	connString := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=disable connect_timeout=1", c.host, c.port, c.user, c.password, c.dbname)
+	connString := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=%s connect_timeout=1", c.host, c.port, c.user, c.password, c.dbname, c.sslmode)
 	for i := 0; i < c.retry; i++ {
 		time.Sleep(time.Duration(c.sleep) * time.Second)
 		db, err := sql.Open("postgres", connString)


### PR DESCRIPTION
Hi @mxssl

First of all, thanks for this project. I'm about to use this but I ran into the `sslmode=disabled` which is hardcoded into the connection string. My server rejects all nonssl connections.

The pg itself returns a list of valid sslmodes if you type in some nosense eg:
```
Error: pq: unsupported sslmode "nosense"; only "require" (default), "verify-full", "verify-ca", and "disable" supported
```

Could you please release this (if you find no issue) so I don't have to build a new image on my own and can keep using your releases?

Thank you!