### PR TITLE
Update dependencies and automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,18 +10,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v6.4.0
         with:
-          go-version: '1.25'
-      - uses: actions/checkout@v6
+          go-version: '1.26.3'
+      - uses: actions/checkout@v6.0.2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@v9.2.1
 
   docker-release:
     needs: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
       - name: Docker login
         run: docker login --username ${{ secrets.DOCKER_LOGIN }} --password ${{ secrets.DOCKER_PASSWORD }}
       - name: Docker release
@@ -31,13 +31,13 @@ jobs:
     needs: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v6.4.0
         with:
-          go-version: '1.25'
+          go-version: '1.26.3'
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@v7.2.2
         with:
           version: latest
           args: release --clean

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 before:
   hooks:
     - go mod download
@@ -15,7 +16,7 @@ archives:
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ .Tag }}"
+  version_template: "{{ .Tag }}"
 changelog:
   sort: asc
   filters:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-FROM golang:1.26.3-alpine3.23 as builder
+FROM golang:1.26.3-alpine3.23 AS builder
 
 WORKDIR /go/src/github.com/mxssl/wait-for-pg
 COPY . .
 
-# Install external dependcies
+# Install external dependencies
 RUN apk add --no-cache \
-	ca-certificates=20251003-r0 \
-	curl=8.17.0-r1 \
+	ca-certificates=20260413-r0 \
+	curl=8.19.0-r0 \
 	git=2.52.0-r0
 
 # Compile binary
@@ -18,6 +18,6 @@ RUN CGO_ENABLED=0 \
 # Copy compiled binary to clear Alpine Linux image
 FROM alpine:3.23
 WORKDIR /
-RUN apk add --no-cache ca-certificates=20251003-r0
+RUN apk add --no-cache ca-certificates=20260413-r0
 COPY --from=builder /go/src/github.com/mxssl/wait-for-pg/wait-for-pg /usr/local/bin/wait-for-pg
 RUN chmod +x /usr/local/bin/wait-for-pg

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/mxssl/wait-for-pg
 
-go 1.25
+go 1.26
+
+toolchain go1.26.3
 
 require (
 	github.com/lib/pq v1.12.3


### PR DESCRIPTION
## Summary
- Update Go module metadata to Go 1.26 with toolchain go1.26.3.
- Pin GitHub Actions to the latest stable tags found for checkout, setup-go, golangci-lint-action, and goreleaser-action.
- Migrate GoReleaser config to version 2 and replace deprecated snapshot.name_template.
- Update Alpine package pins in the Dockerfile for ca-certificates and curl.

## Validation
- go mod tidy
- go test ./...
- goreleaser check
- goreleaser build --snapshot --clean
- docker manifest inspect golang:1.26.3-alpine3.23
- docker manifest inspect alpine:3.23
